### PR TITLE
Adds commands for adding Stores, Apps, and Webhooks

### DIFF
--- a/app/Console/Commands/AttachWebhook.php
+++ b/app/Console/Commands/AttachWebhook.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreWebhook;
+use Illuminate\Console\Command;
+
+class AttachWebhook extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:attach-webhook
+                          {--store-id= : Store ID to attach webhook to}
+                          {--url= : Webhook URL}
+                          {--active= : Whether webhook is active (true/false)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Attach a webhook to a Polydock Store';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Attaching webhook to Polydock Store...');
+
+        // Get all stores for selection
+        $stores = PolydockStore::all();
+        
+        if ($stores->isEmpty()) {
+            $this->error('No stores found. Please create a store first.');
+            return 1;
+        }
+
+        // Select store
+        $storeId = $this->option('store-id');
+        if (!$storeId) {
+            $storeOptions = $stores->mapWithKeys(function ($store) {
+                return [$store->id => "{$store->name} (ID: {$store->id})"];
+            })->toArray();
+            
+            $selectedStoreValue = $this->choice('Select a store to attach webhook to:', $storeOptions);
+            $storeId = collect($storeOptions)->search($selectedStoreValue);
+            if(empty($storeId)) {
+                $this->error("Unable to find store ID");
+                exit(1);
+            }
+        }
+
+        // Validate store exists
+        $store = PolydockStore::find($storeId);
+        if (!$store) {
+            $this->error("Store with ID {$storeId} not found.");
+            return 1;
+        }
+
+        // Get webhook URL
+        $webhookUrl = $this->option('url') ?? $this->ask('Webhook URL');
+        if (empty($webhookUrl)) {
+            $this->error('Webhook URL is required. Exiting...');
+            return 1;
+        }
+
+        // Get active status
+        $activeInput = $this->option('active') ?? $this->choice('Should the webhook be active?', ['true', 'false']);
+        $active = filter_var($activeInput, FILTER_VALIDATE_BOOLEAN);
+
+        // Create the webhook
+        $webhook = PolydockStoreWebhook::create([
+            'polydock_store_id' => $store->id,
+            'url' => $webhookUrl,
+            'active' => $active,
+        ]);
+
+        $this->info("✅ Webhook attached successfully to store '{$store->name}' with ID: {$webhook->id}");
+        $this->line("   URL: {$webhook->url}");
+        $this->line("   Active: " . ($webhook->active ? 'Yes' : 'No'));
+        
+        return 0;
+    }
+}

--- a/app/Console/Commands/CreateStore.php
+++ b/app/Console/Commands/CreateStore.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PolydockStoreStatusEnum;
+use App\Models\PolydockStore;
+use Illuminate\Console\Command;
+
+class CreateStore extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:create-store
+                          {--name= : Store name}
+                          {--status= : Store status (public/private)}
+                          {--listed= : Listed in marketplace (true/false)}
+                          {--region-id= : Lagoon deploy region ID}
+                          {--prefix= : Lagoon deploy project prefix}
+                          {--org-id= : Lagoon deploy organization ID}
+                          {--ai-region-id= : Amazee AI backend region ID}
+                          {--group-name= : Lagoon deploy group name}
+                          {--deploy-key= : Custom deploy private key (optional)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Polydock Store with interactive prompts';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Creating a new Polydock Store...');
+        
+        // Gather store information
+        $name = $this->option('name') ?? $this->ask('Store name');
+        
+        $status = $this->option('status') ?? $this->choice(
+            'Store status', 
+            ['public', 'private']
+        );
+        
+        $listedInput = $this->option('listed') ?? $this->choice(
+            'Listed in marketplace?', 
+            ['true', 'false']
+        );
+        $listed = filter_var($listedInput, FILTER_VALIDATE_BOOLEAN);
+        
+        $regionId = $this->option('region-id') ?? $this->ask('Lagoon deploy region ID');
+        
+        $prefix = $this->option('prefix') ?? $this->ask('Lagoon deploy project prefix');
+        
+        $orgId = $this->option('org-id') ?? $this->ask('Lagoon deploy organization ID');
+        
+        $aiRegionId = $this->option('ai-region-id') ?? $this->ask('Amazee AI backend region ID');
+        
+        $groupName = $this->option('group-name') ?? $this->ask('Lagoon deploy group name');
+
+        // Check if all required values are set
+        if (empty($name) || empty($status) || empty($regionId) || empty($prefix) || empty($orgId) || empty($aiRegionId) || empty($groupName)) {
+            $this->error('All fields are required. Exiting...');
+            return 1;
+        }
+
+        // Get deploy key - allow override
+        $customDeployKey = $this->option('deploy-key');
+        
+        if (!$customDeployKey && $this->confirm('Do you want to use a custom deploy private key? (Press no to use default from config)')) {
+            $this->info('Please paste your private key (multi-line input supported):');
+            $customDeployKey = $this->secret('Deploy private key');
+        }
+        
+        if ($customDeployKey) {
+            $deployKey = $customDeployKey;
+        } else {
+            $deployKey = file_get_contents(config('polydock.lagoon_deploy_private_key_file'));
+        }
+
+        if(empty($deployKey)) {
+            $this->error("No deploy key available - either provide one or ensure config file exists");
+            return 1;
+        }
+
+        // Create the store
+        $store = PolydockStore::create([
+            'name' => $name,
+            'status' => $status === 'public' ? PolydockStoreStatusEnum::PUBLIC : PolydockStoreStatusEnum::PRIVATE,
+            'listed_in_marketplace' => $listed,
+            'lagoon_deploy_region_id_ext' => $regionId,
+            'lagoon_deploy_project_prefix' => $prefix,
+            'lagoon_deploy_organization_id_ext' => $orgId,
+            'lagoon_deploy_private_key' => $deployKey,
+            'amazee_ai_backend_region_id_ext' => $aiRegionId,
+            'lagoon_deploy_group_name' => $groupName
+        ]);
+
+        $this->info("✅ Store '{$store->name}' created successfully with ID: {$store->id}");
+        
+        return 0;
+    }
+}

--- a/app/Console/Commands/CreateStoreApp.php
+++ b/app/Console/Commands/CreateStoreApp.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PolydockStoreAppStatusEnum;
+use App\Models\PolydockStore;
+use App\Models\PolydockStoreApp;
+use Illuminate\Console\Command;
+
+class CreateStoreApp extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'polydock:create-store-app
+                          {--store-id= : Store ID to create app in}
+                          {--name= : App name}
+                          {--app-class= : Polydock app class}
+                          {--description= : App description}
+                          {--author= : App author}
+                          {--website= : Author website}
+                          {--support-email= : Support email}
+                          {--git= : Lagoon deploy git repository}
+                          {--branch= : Lagoon deploy branch}
+                          {--status= : App status}
+                          {--trials= : Available for trials (true/false)}
+                          {--target-instances= : Target unallocated app instances}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new App in a Polydock Store';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Creating new App in Polydock Store...');
+
+        // Get all stores for selection
+        $stores = PolydockStore::all();
+        
+        if ($stores->isEmpty()) {
+            $this->error('No stores found. Please create a store first.');
+            return 1;
+        }
+
+        // Select store
+        $storeId = $this->option('store-id');
+        if (!$storeId) {
+            $storeOptions = $stores->mapWithKeys(function ($store) {
+                return [$store->id => "{$store->name} (ID: {$store->id})"];
+            })->toArray();
+
+            $selectedValue = $this->choice('Select a store to create app in:', $storeOptions);
+            $storeId = collect($storeOptions)->search($selectedValue);
+        }
+
+        // Validate store exists
+        $store = PolydockStore::find($storeId);
+        if (!$store) {
+            $this->error("Store with ID {$storeId} not found.");
+            return 1;
+        }
+
+        // Gather app information
+        $name = $this->option('name') ?? $this->ask('App name');
+        $appClass = $this->option('app-class') ?? $this->ask('Polydock app class');
+        $description = $this->option('description') ?? $this->ask('App description');
+        $author = $this->option('author') ?? $this->ask('Author');
+        $website = $this->option('website') ?? $this->ask('Author website');
+        $supportEmail = $this->option('support-email') ?? $this->ask('Support email');
+        $git = $this->option('git') ?? $this->ask('Lagoon deploy git repository');
+        $branch = $this->option('branch') ?? $this->ask('Lagoon deploy branch');
+        
+        $statusInput = $this->option('status') ?? $this->choice('App status', [
+            'available' => 'Available',
+            'unavailable' => 'Unavailable',
+            'deprecated' => 'Deprecated'
+        ]);
+        $status = match($statusInput) {
+            'available', 'Available' => PolydockStoreAppStatusEnum::AVAILABLE,
+            'unavailable', 'Unavailable' => PolydockStoreAppStatusEnum::UNAVAILABLE,
+            'deprecated', 'Deprecated' => PolydockStoreAppStatusEnum::DEPRECATED,
+            default => PolydockStoreAppStatusEnum::AVAILABLE
+        };
+        
+        $trialsInput = $this->option('trials') ?? $this->choice('Available for trials?', ['true', 'false']);
+        $trials = filter_var($trialsInput, FILTER_VALIDATE_BOOLEAN);
+        
+        $targetInstances = $this->option('target-instances') ?? $this->ask('Target unallocated app instances');
+        if($targetInstances == "") {
+            $targetInstances = 0;
+        }
+
+        // Check if all required values are set
+        if (empty($name) || empty($appClass) || empty($description) || empty($author) || 
+            empty($website) || empty($supportEmail) || empty($git) || empty($branch) || 
+            ($targetInstances != 0 && empty($targetInstances))) {
+            $this->error('All fields are required. Exiting...');
+            return 1;
+        }
+
+        // Create the store app
+        $storeApp = PolydockStoreApp::create([
+            'polydock_store_id' => $store->id,
+            'name' => $name,
+            'polydock_app_class' => $appClass,
+            'description' => $description,
+            'author' => $author,
+            'website' => $website,
+            'support_email' => $supportEmail,
+            'lagoon_deploy_git' => $git,
+            'lagoon_deploy_branch' => $branch,
+            'status' => $status,
+            'available_for_trials' => $trials,
+            'target_unallocated_app_instances' => intval($targetInstances),
+        ]);
+
+        $this->info("✅ App '{$storeApp->name}' created successfully in store '{$store->name}' with ID: {$storeApp->id}");
+        $this->line("   App Class: {$storeApp->polydock_app_class}");
+        $this->line("   Git Repository: {$storeApp->lagoon_deploy_git}");
+        $this->line("   Available for Trials: " . ($storeApp->available_for_trials ? 'Yes' : 'No'));
+        
+        return 0;
+    }
+}


### PR DESCRIPTION
This pull request introduces three new artisan console commands to streamline management of Polydock Stores, Store Apps, and Webhooks via the command line. Each command provides interactive prompts and options for creating and attaching resources.

This obviates the need to use the seeder functionality to add these items.

### New Console Commands

**Store Management**
* Added `CreateStore` command (`app: create-store`) to interactively create new Polydock Stores, supporting options for name, status, marketplace listing, deployment configuration, and custom deploy keys.

**Store App Management**
* Added `CreateStoreApp` command (`polydock: create-store-app`) to create new Apps within a selected Polydock Store, allowing specification of app details, deployment settings, status, trial availability, and target instance count.

**Webhook Management**
* Added `AttachWebhook` command (`polydock: attach-webhook`) to attach a webhook to a selected Polydock Store, with options for webhook URL and active status.