### PR TITLE
Adds Ireland cluster

### DIFF
--- a/config/polydock.php
+++ b/config/polydock.php
@@ -12,12 +12,12 @@
             'ssh_port' => env('FTLAGOON_SSH_PORT','32222'),
             'endpoint' => env('FTLAGOON_ENDPOINT','https://api.lagoon.amazeeio.cloud/graphql'), 
         ],
-        "PolydockServiceProviderAmazeeAiBackend" => [
-            'class' => App\PolydockServiceProviders\PolydockServiceProviderAmazeeAiBackend::class,
-            'debug' => false,
-            'base_url' => env('AMAZEE_AI_BACKEND_BASE_URL', 'https://backend.main.amazeeai.us2.amazee.io'),
-            'token_file' => env('AMAZEE_AI_BACKEND_TOKEN_FILE', storage_path('amazee-ai-backend/token')),
-        ]
+        // "PolydockServiceProviderAmazeeAiBackend" => [
+        //     'class' => App\PolydockServiceProviders\PolydockServiceProviderAmazeeAiBackend::class,
+        //     'debug' => false,
+        //     'base_url' => env('AMAZEE_AI_BACKEND_BASE_URL', 'https://backend.main.amazeeai.us2.amazee.io'),
+        //     'token_file' => env('AMAZEE_AI_BACKEND_TOKEN_FILE', storage_path('amazee-ai-backend/token')),
+        // ]
       ];
     
     $filterServiceProviders = explode(",", env('POLYDOCK_DISABLED_SERVICE_PROVIDERS', ''));
@@ -143,6 +143,15 @@ return [
                     'pattern' => 'us3.amazee.io',
                     'country' => 'United States',
                     'country_code' => 'US',
+                ],
+                '183' => [
+                    'id' => '183',
+                    'code' => 'IE1',
+                    'provider' => 'AWS',
+                    'name' => 'Ireland',
+                    'pattern' => 'ie1.amazee.io',
+                    'country' => 'Ireland',
+                    'country_code' => 'IE',
                 ]
             ]
         ]


### PR DESCRIPTION
This pull request makes two main changes to the `config/polydock.php` configuration file: it disables the Amazee AI Backend service provider by commenting out its configuration, and it adds a new region for Ireland to the list of available regions.

Service provider configuration changes:

* Disabled the `PolydockServiceProviderAmazeeAiBackend` by commenting out its configuration block, which includes its class, debug setting, base URL, and token file path.

Region configuration updates:

* Added a new region entry for Ireland (`id: 183`, `code: IE1`, `provider: AWS`, `name: Ireland`, `pattern: ie1.amazee.io`, `country: Ireland`, `country_code: IE`) to the regions array.