### PR TITLE
Fixes namespace of create-store command

### DIFF
--- a/app/Console/Commands/CreateStore.php
+++ b/app/Console/Commands/CreateStore.php
@@ -13,7 +13,7 @@ class CreateStore extends Command
      *
      * @var string
      */
-    protected $signature = 'app:create-store
+    protected $signature = 'polydock:create-store
                           {--name= : Store name}
                           {--status= : Store status (public/private)}
                           {--listed= : Listed in marketplace (true/false)}


### PR DESCRIPTION
This pull request updates the command signature in the `CreateStore` console command to use a more descriptive and consistent prefix.

Command signature update:

* Changed the command signature in `CreateStore` (`app/Console/Commands/CreateStore.php`) from `app:create-store` to `polydock:create-store`, improving clarity and consistency with other commands.